### PR TITLE
Fixed player burns on after selecting kit when on fire

### DIFF
--- a/src/main/java/de/hglabor/plugins/ffa/kit/KitSelectorImpl.java
+++ b/src/main/java/de/hglabor/plugins/ffa/kit/KitSelectorImpl.java
@@ -69,6 +69,7 @@ public class KitSelectorImpl extends KitSelector {
                 player.closeInventory();
                 if (ffaPlayer.getKits().stream().noneMatch(kits -> kits.equals(NoneKit.INSTANCE))) {
                     FFA.getArenaManager().teleportToArena(player);
+                    player.setFireTicks(0);
                 }
             }
         }


### PR DESCRIPTION
Before the player would just burn on and get fire damage when he already was burning whilst selecting a kit. This PR fixes this by extinguishes the player after the selection of a kit.